### PR TITLE
Suggesting a module on PIDs

### DIFF
--- a/07a-Working-with-PIDs_CURL.md
+++ b/07a-Working-with-PIDs_CURL.md
@@ -1,0 +1,362 @@
+# Working with Persistent Identifiers - Hands-on
+This lecture takes you through the steps to create and administer PIDs employing the HTTP restful API.
+
+
+## Warming-up: Using PIDs
+Below  you find three different PIDs and their corresponding global resolver
+
+- Handle 
+
+    PID: 11304/cf8956a2-39d3-11e5-8a18-f31aa6f4d448
+
+    Resolver: http://hdl.handle.net/
+
+- Doi
+
+    PID: 10.3389/fgene.2013.00289
+
+    Resolver: http://dx.doi.org/
+
+- Ark 
+
+    PID: ark:/13030/tf5p30086k
+
+    Resolver: https://nbn-resolving.org/
+
+You can either go to the resolver in your web browser and type in the PID to get to the data behind it. You can also concatenate the resolver and the PID.
+
+**Try to resolve the handle PID with the DOI resolver and vice versa.**
+
+**In the handle resolver you will find a box "Don't redirect to URLs", if you tick this box, what information do you get?**
+
+Each PID consists of a *prefix* which is linked to an administratory domain (e.g. a journal) and a *suffix*. The prefix is handed out by an issuer such as CNRI for handle or DataCite for DOIs. Once you are admin of a prefix, you can register as many data objects as you want by extending the prefix with a suffix. Note, that the suffixes need to be unique for each data object. The epic client helps you with that.
+
+## Managing PIDs
+
+### Prerequisites
+
+The code is based on cURL. cURL is an open source command line tool and library for transferring data with URL syntax. cURL is used in command lines or scripts to transfer data.
+
+ * Please check the dependencies before you start.
+ * You will also need test credentials for the epic server.
+
+
+#### Install cURL dependencies
+
+CURL: is an open source command line tool and library for transferring data with URL syntax.
+On the training machines 
+
+```py
+apt-get install curl 
+apt-get install uuid-runtime 
+```
+
+#### Own laptop
+
+In case you are working on your own laptop with your own python, please install:
+
+```py
+easy_install curl
+easy_install uuid-runtime
+```
+
+Final check
+
+```py
+curl --help
+```
+
+If you write the code described below in a file, don't forget to change the permissions. 
+You should make each file executable. 
+
+Suppose you have a file `filename.sh` 
+
+you can make it by doing as:
+`chmod +x filename.sh`
+
+so it will execute when you type
+`./filename.sh`
+
+
+#### Example workflow
+
+1. Obtain a prefix from an resolver admin
+2. Set up internet connection to the PID server with a client
+3. Create a PID
+4. Link PID and location of the data object
+
+In the tutorial below we will work with a test handle server located at SURFsara. 
+That means the PIDs we create are not resolvable via the global handle resolver or via the DOI resolver.
+
+#### For resolving PIDs please use:
+
+`http://epic3.storage.surfsara.nl:8001`
+
+### Main Parameters of CURL 
+
+The main command
+ 
+  `curl [options] [URL...]`
+  
+  
+Before we start, lets explain the main parameters of CURL used as options 
+
+ * **-X, --request <command>**: (HTTP) Specifies a custom request method to use when communicating with the HTTP server. The specified request method will be used instead of the method otherwise used (which defaults to GET).  Common additional HTTP requests include PUT ,POST and DELETE . ( -X GET) 
+ * **-U, --proxy-user <user:password>**: Specify the user name and password to use for proxy authentication. (ex: -u "username:pass) 
+ * **-H, --header <header>**: Extra header to include in the request when sending HTTP to a server. You may specify any number of extra headers.(ex: -H "Accept: application/json" so as to accept json data)
+ * **-d, --data <data>**: (HTTP) Sends the specified data in a POST or PUT request to the HTTP server, in the same way that a browser does when a user has filled in an HTML form and presses the submit button. 
+ * **-D, --dump-header <file>**: Write the protocol headers to the specified file.
+ * **-v**: get verbosed information about the connection with the server 
+ 
+These are the main parameters we are going to use in our examples. For more parameters please check [cURL]Chttps://curl.haxx.se/)
+
+### Connect to the SURFsara handle server 
+
+To connect to the epic server you need to provide a prefix and a password. 
+If you use the example files, this information is stored in a *config.txt* file  and should look like this:
+
+```py
+USERNAME=846
+PASSWORD=xxxx
+FILENAME=surveys.csv #the file (and its location) we are going to use in the examples
+PID_SERVER=https://epic3.storage.surfsara.nl/v2_test/handles/846 #be carefull not to add the trailing slash
+PID_SUFFIX=XXXX #the suffix of the first created handle
+PID2_SUFFIX=YYYY #the suffix of the second handle
+```
+You can find the the username and password on the user interface machine in *credentials/cred_epic/cred_file.json*.
+
+ - Get the list of handles in 846 prefix as an example. 
+```py
+curl -u "846:XXX" -H "Accept: application/json" \
+	 -H "Content-Type: application/json" \
+	 https://epic3.storage.surfsara.nl/v2_test/handles/846/
+```
+
+- Connect with your credentials (username, password)
+```py
+-u "846:XXX"
+```
+- Use the correct headers to send and accept json format 
+
+```py
+-H "Accept: application/json" -H "Content-Type: application/json"
+```
+
+- The PID prefix is combined with the pid server url  
+
+```py
+https://epic3.storage.surfsara.nl/v2_test/handles/846/
+```
+
+## Registering a file
+
+### We will register a public file from figshare. 
+
+First prepare the data in a json format to register. 
+
+```py
+'[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}]'
+```
+
+We are going to create a new PID by using the PUT request
+
+So the request method is -X PUT followed by the actual json data 
+
+```py
+-X PUT --data '[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}]'
+```
+
+### Building the PID:
+
+- Create a universally unique identifier (uuid)
+- Take function for this from
+```py
+SUFFIX=`uuidgen`
+```
+
+- Concatenate your PID prefix and the uuid to create the full PID
+` 846/$SUFFIX `
+
+We now have an opaque string which is unique to our resolver (846/$SUFFIX ) since
+the prefix is unique (handed out by administrators of the resolver).
+
+The URL in the CURL request: 
+```py
+https://epic3.storage.surfsara.nl/v2_test/handles/846/$SUFFIX 
+```
+
+- Register the PID, link the PID and the data object. We would like the PID to point to the location we stored in *fileLocation*
+(example1.sh)
+
+```py
+#!/bin/bash    
+
+SUFFIX=`uuidgen`
+
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X PUT --data '[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/$SUFFIX 
+```
+
+The result of this request is a new handle with the name HANDLE where
+HANDLE = 846/UUID1
+
+#### Responses 
+ - HTTP/1.1 201 Created: (Success)
+ - HTTP/1.1 204 No-Content: The local name already exists , and instead of creating a new one you’ve just updated the values of an existing one.
+ - HTTP/1.1 401 Unauthorized: Your username or your password is wrong
+ - HTTP/1.1 405 Method Not Allowed: 
+ 	- You are trying to create a new handle in the main url of the server either (https://epic.grnet.gr/handles/11239/) or (https://epic.grnet.gr/handles). You have not specified a unique name for your handle. (or)
+	- You are trying to create a new handle with manual generation of suffix name via POST instead of PUT. POST supports automatic generation of suffix name.
+ - HTTP/1.1 415 Unsupported Media Type: You haven’t specify the correct headers for your request. The service supports Json representation so you must define the content-type of the request.
+
+
+Let’s go to the resolver and see what is stored there
+`http://epic3.storage.surfsara.nl:8001`. 
+We can get some information on the data from the resolver.
+We can retrieve the data object itself via the web-browser.
+
+**Download the file via the resolver. Try to use *wget* when working remotely on our training machine.**
+
+**How is the data stored when downloading via the browser and how via *wget*?**
+
+**Have a look at the metadata stored in the PID entry.**
+
+**What happens if you try to reregister the file with the same PID?** 
+
+Dont forget to change the UUD1 to the correct suffix value.
+
+```py
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X PUT --data '[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/UUID1 
+```
+(Use example2.sh)
+
+### Store some handy information with your file
+
+- We can store some more information in the PID entry by modifying the json data 
+
+Lets say that we want to add a new type with data 'Data Carpentry pandas example file'.
+We have to update the json data
+```
+[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}, 
+ {"type":"TYPE","parsed_data":"Data Carpentry pandas example file"}]
+
+```
+
+And the actual request is:
+
+```py
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X PUT --data '[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}, {"type":"TYPE","parsed_data":"Data Carpentry pandas example file"}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/UUID1
+```
+
+Use example3.sh
+
+- We want to store information on identity of the file, e.g. the md5 checksum. We first have 
+to generate the checksum. However, we can only create checksums for files which we 
+have access to with our python compiler. In the step above we can download the file and
+then continue to calculate the checksum. **NOTE** the filename might depend on the download method.
+
+```#!/bin/bash
+md5value=` md5 surveys.csv | awk '{ print $4 }'`
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X POST --data '[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}, 
+ 					    {"type":"TYPE","parsed_data":"Data Carpentry pandas example file"}, 
+ 					    {"type":"MD5","parsed_data":$md5value}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/UUID1
+
+```
+
+Use example4.sh
+
+- With the resolver we can access this information. Note, this data is publicly available to anyone.
+
+### Reverse look-ups
+The epic API extends the handle API with recursive look-ups. Assume you just know some of the metadata stored with a PID but not the full PID. How can you get to the URL field to retrieve the data?
+
+We can fetch the first data with a certain checksum:
+```py
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X GET \
+		https://epic3.storage.surfsara.nl/v2_test/handles/846/?MD5=MD5VALUE
+```
+
+Use example5.sh
+
+#### Responses 
+ - HTTP/1.1 200 OK: (Success)
+ - HTTP/1.1 401 Unauthorized: Your username or your password is wrong
+ - HTTP/1.1 404 NOT found: The url doesn’t exist
+ 
+### Updating PID entries
+- Assume location of file has changed. This means we need to modify the URL field.
+
+```py
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X POST --data '[{"type":"URL","parsed_data":"/<PATH>/surveys.csv"}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/UUID1
+```
+
+Use example6.sh
+
+#### Responses
+ - HTTP/1.1 204 No-Content: The local name already exists , and instead of creating a new one you’ve just updated the values of an existing one.
+ - HTTP/1.1 401 Unauthorized: Your username or your password is wrong
+ - HTTP/1.1 415 Unsupported Media Type: You haven’t specify the correct headers for your request. The service supports Json representation so you must define the content-type of the request.
+ 
+**Try to fetch some metadata on the file from the resolver.**
+
+**Try to resolve directly to the file. What happens?**
+
+We updated the "URL" with a local path on a personal machine. That means you can no longer download the data
+directly, but you have access to the data stored in the PID.
+
+* Information stored with the PID is ALWAYS public
+* Data itself can lie on a protected server/computer and not be accessible for everyone
+
+### Linking two files
+
+We know that the file in the figshare repository and our local file are identical. We want to store this information
+in the PIDs.
+
+- Reregister the figshare file
+- First create a new PID
+```py
+#!/bin/bash    
+
+SUFFIX=`uuidgen`
+
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X PUT --data '[{"type":"URL","parsed_data":"https://ndownloader.figshare.com/files/2292172"}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/$SUFFIX 
+```
+
+- Leave information that local file should be the same as the figshare file. Update the data of handle 
+
+First update the json 
+```
+	[{"type":"URL","parsed_data":"/<PATH>/surveys.csv"},{"type":"SAME_AS","parsed_data":"846/newhandle"}]
+```
+
+```py
+curl -v -u "YOURUSERNAME:YOURPASSWORD" -H "Accept:application/json" \
+		-H "Content-Type:application/json" \
+		-X POST --data '[{"type":"URL","parsed_data":"/<PATH>/surveys.csv",},{"type":"SAME_AS","parsed_data":"846/newhandle"}]'\
+		 https://epic3.storage.surfsara.nl/v2_test/handles/846/UUID1
+```
+
+
+
+
+These examples are adjusted to the functionality in the EUDAT B2SAFE service, but can serve as reference implementation for other use cases.
+

--- a/07b-Working-with-PIDs_epicclient.md
+++ b/07b-Working-with-PIDs_epicclient.md
@@ -1,0 +1,259 @@
+# Working with Persistent Identifiers - Hands-on
+This lecture illustrates the use of PIDs, more specifically it shows how to employ [handles](handle.net) using the epicclient and [EPIC API](http://www.pidconsortium.eu/).
+
+## Warming-up: Using PIDs
+Below  you find three different PIDs and their corresponding global resolver
+
+- Handle 
+
+    PID: 11304/cf8956a2-39d3-11e5-8a18-f31aa6f4d448
+
+    Resolver: http://hdl.handle.net/
+
+- Doi
+
+    PID: 10.3389/fgene.2013.00289
+
+    Resolver: http://dx.doi.org/
+
+- Ark 
+
+    PID: ark:/13030/tf5p30086k
+
+    Resolver: https://nbn-resolving.org/
+
+You can either go to the resolver in your webbrowser and type in the PID to get to the data behind it. You can also concatenate the resolver and the PID.
+
+**Try to resolve the handle PID with the DOI resolver and vice versa.**
+
+**In the handle resolver you will find a box "Don't redirect to URLs", if you tick this box, what information do you get?**
+
+Each PID consists of a *prefix* which is linked to an administratory domain (e.g. a journal) and a *suffix*. The prefix is handed out by an issuer such as CNRI for handle or DataCite for DOIs. Once you are admin of a prefix, you can register as many data objects as you want by extending the prefix with a suffix. Note, that the suffixes need to be unique for each data object. The epic client helps you with that.
+
+
+## Managing PIDs
+### Prerequisites
+
+The code is based on the [epicclient.py](https://github.com/EUDAT-B2SAFE/B2SAFE-core/blob/master/cmd/epicclient.py).
+Please check the dependencies before you start.
+You will also need test credentials for the epic server. On the user interface, credentials are located in *credentials/cred_epic*
+
+Please download the epicclient.py.
+```sh
+wget https://raw.githubusercontent.com/EUDAT-Training/B2SAFE-B2STAGE-Training/develop/code/epicclient.py
+```
+
+#### Install python dependencies
+
+On the user interface machine you will find python compiler preinstalled with all neceassary dependencies, we also offer ipython for convenient testing:
+```sh
+python
+```
+or
+```
+ipython
+```
+
+#### Own laptop
+In case you are working on your own laptop with your own python, please install:
+
+```sh
+easy_install httplib2
+easy_install simplejson
+easy_install lxml
+easy_install defusedxml
+```
+
+Final check
+
+```sh
+python epicclient.py --help
+```
+
+## Managing PIDs 
+How do repositories create PIDs for data objects?
+How can you create a PID for your own data objects?
+
+#### Example workflow
+1. Obtain a prefix from an resolver admin
+2. Set up internet connection to the PID server with a client
+3. Create a PID
+4. Link PID and location of the data object
+
+In the tutorial below we will work with a test handle server located at SURFsara. That means the PIDs we create are not resolvable via the global handle resolver or via the DOI resolver.
+
+#### For resolving PIDs please use:
+`http://epic3.storage.surfsara.nl:8001`
+
+### Import necessary libraries:
+
+```py
+from epicclient import EpicClient, LocationType, Credentials
+import uuid
+import hashlib
+import os, shutil
+```
+### Connect to the SURFsara handle server 
+To connect to the epic server you need to provide a prefix and a password. This information is stored in a json file *credentials* and should look like this:
+```sh
+{
+    "baseuri": "https://epic3.storage.surfsara.nl/v2_test/handles/",
+    "username": "846",
+    "prefix": "846",
+    "password": "XXX",
+    "accept_format": "application/json",
+    "debug" : "False"
+}
+```
+On the test machines you can find such a file in */opt/PIDs*.
+
+- Parse credentials (username, password)
+```py
+cred = Credentials('os', '/<PATH>/cred_file.json')
+cred.parse()
+```
+- Retrieve some information about the server, this server also hosts the resolver which we will use later
+```py
+ec = EpicClient(cred)
+print('PID server ' + ec.cred.baseuri)
+```
+- The PID prefix is your user name which is coupled to an administratory domain
+```py
+print('PID prefix ' + ec.cred.prefix)
+```
+
+## Registering a file
+### We will register a public file from figshare. 
+First store the file location.
+```py
+fileLocation = 'https://ndownloader.figshare.com/files/2292172'
+```
+
+### Building the PID:
+- Create a universally unique identifier (uuid)
+- Take function for this from
+```py
+import uuid
+uid = uuid.uuid1()
+print(uid)
+print(type(uid))
+```
+
+- Concatenate your PID prefix and the uuid to create the full PID
+```py
+pid = cred.prefix + '/' + str(uid)
+print(pid)
+```
+
+We now have an opaque string which is unique to our resolver since
+the prefix is unique (handed out by administrators of the resolver).
+The suffix has been created with the uuid function. 
+
+- Link the PID and the data object. We would like the PID to point to the location we stored in *fileLocation*
+
+```py
+Handle = ec.createHandle(pid, fileLocation)
+```
+
+Let’s go to the resolver and see what is stored there
+`http://epic3.storage.surfsara.nl:8001`. 
+We can get some information on the data from the resolver.
+We can retrieve the data object itself via the web-browser.
+
+**Download the file via the resolver. Try to use *wget* when working remotely on our training machine.**
+
+**How is the data stored when downloading via the browser and how via *wget*?**
+
+**Have a look at the metadata stored in the PID entry.**
+
+**What happens if you try to reregister the file with the same PID?**
+```py
+newHandle = ec.createHandle(pid, fileLocation)
+```
+
+### Store some handy information with your file
+- We can store some more information in the PID entry with the function *modifyHandle*
+```py
+?ec.modifyHandle
+ec.modifyHandle(Handle, 'TYPE', 'Data Carpentry pandas example file')
+```
+
+- We want to store information on identity of the file, e.g. the md5 checksum. We first have 
+to generate the checksum. However, we can only create checksums for files which we 
+have access to with our python compiler. In the step above we can download the file and
+then continue to calculate the checksum. **NOTE** the filename might depend on the download method.
+
+```py
+import hashlib
+md5sum = hashlib.md5('/<PATH>/surveys.csv').hexdigest()
+ec.modifyHandle(Handle, 'MD5', md5sum)
+```
+
+- With the resolver we can access this information. Note, this data is publicly available to anyone.
+
+- We can also access the information via the client:
+    ```py
+    ec.retrieveHandle(Handle)
+    ```
+
+### Updating PID entries
+- Assume location of file has changed. This means we need to modify the URL field.
+
+```py
+ec.modifyHandle(Handle, 'URL', '/<PATH>/surveys.csv')
+```
+
+**Try to fetch some metadata on the file from the resolver.**
+
+**Try to resolve directly to the file. What happens?**
+
+We updated the "URL" with a local path on a personal machine. That means you can no longer download the data
+directly, but you have access to the data stored in the PID.
+
+* Information stored with the PID is ALWAYS public
+* Data itself can lie on a protected server/computer and not be accessible for everyone
+
+## Linking two files
+We know that the file in the figshare repository and our local file are identical. We want to store this information
+in the PIDs.
+
+- Reregister the figshare file
+- First create a new PID
+```py
+uid = uuid.uuid1()
+print(uid)
+pid = cred.prefix + '/' + str(uid)
+```
+searchHandle(self, prefix, key, value)
+
+- Link the new PID/handle to the public figshare data which is still stored in *fileLocation*
+
+```py
+newHandle = ec.createHandle(pid, fileLocation)
+```
+
+- Leave information that local file should be the same as the figshare file
+
+```py
+ec.modifyHandle(Handle, 'Same_as', newHandle)
+```
+
+### Reverse look-ups
+The epic API extends the handle API with reverse look-ups. Assume you just know some of the metadata stored with a PID but not the full PID. How can you get to the URL field to retrieve the data?
+
+We can fetch the first data with a certain checksum:
+```py
+Handle = ec.searchHandle(cred.prefix, 'MD5', md5sum)
+url = ec.getValueFromHandle(Handle, 'URL')
+print(url) 
+```
+
+### Using the epicclient Command Line Interface (CLI)
+For now we directly worked with the raw functions. The epicclient can also be used as CLI. 
+You can list all options for the CLI on the commandline with:
+
+```sh 
+/opt/epd73/bin/python epicclient.py os /opt/PIDs/credentials -h
+```
+
+The functions are adjusted to the functionality in the EUDAT B2SAFE service, but can serve as reference implementation for other use cases.

--- a/07c-Working-with-PIDs_B2HANDLE.md
+++ b/07c-Working-with-PIDs_B2HANDLE.md
@@ -1,0 +1,245 @@
+# Working with Persistent Identifiers - Hands-on
+This lecture illustrates the use of PIDs, more specifically it shows how to employ [handles](handle.net) using the [B2HANDLE library](https://github.com/EUDAT-B2SAFE/B2HANDLE).
+
+## Prerequisites
+If you are not working on one of our test machines you need to install the B2HANDLE library and apply for a prefix. For instructions please follow the documentation:
+
+https://github.com/EUDAT-B2SAFE/B2HANDLE/blob/master/README.md
+
+http://eudat-b2safe.github.io/B2HANDLE/handleclient.html#authentication
+
+## Warming-up: Using PIDs
+Below  you find three different PIDs and their corresponding global resolver
+
+- Handle 
+
+    PID: 11304/cf8956a2-39d3-11e5-8a18-f31aa6f4d448
+
+    Resolver: http://hdl.handle.net/
+
+- Doi
+
+    PID: 10.3389/fgene.2013.00289
+
+    Resolver: http://dx.doi.org/
+
+- Ark 
+
+    PID: ark:/13030/tf5p30086k
+
+    Resolver: https://nbn-resolving.org/
+
+You can either go to the resolver in your webbrowser and type in the PID to get to the data behind it. You can also concatenate the resolver and the PID.
+
+**Try to resolve the handle PID with the DOI resolver and vice-versa.**
+
+**In the handle resolver you will find a box "Don't redirect to URLs", if you tick this box, what information do you get?**
+
+Each PID consists of a *prefix* which is linked to an administratory domain (e.g. a journal) and a *suffix*. The prefix is handed out by an issuer such as CNRI for handle or DataCite for DOIs. Once you are admin of a prefix, you can register as many data objects as you want by extending the prefix with a suffix. Note, that the suffixes need to be unique for each data object. The epic client helps you with that.
+
+
+## Managing PIDs
+
+#### Training machine
+On our user interface machines we already installed all necessary packages and the B2HANDLE library. You will find your credentaials for this tutorials in the folder */home/<user>/credentials/cred_b2handle*. 
+
+#### Own laptop
+In case you are working on your own laptop with your own python, please install the B2HANDLE library.
+
+## Managing PIDs 
+How do repositories create PIDs for data objects?
+How can you create a PID for your own data objects?
+
+#### Example workflow
+1. Obtain a prefix from an resolver admin (See Prerequisites)
+2. Set up internet connection to the PID server with a client
+3. Create a PID
+4. Link PID and location of the data object
+
+In the tutorial below we will work with a test handle server located at SURFsara. That means the PIDs we create are not resolvable via the global handle resolver or via the DOI resolver.
+
+#### For resolving PIDs please use:
+`http://epic3.storage.surfsara.nl:8001`
+
+### Import necessary libraries:
+
+```py
+from b2handle.clientcredentials import PIDClientCredentials
+from b2handle.handleclient import EUDATHandleClient
+
+import uuid
+import hashlib
+import os, shutil
+```
+### Connect to the SURFsara handle server 
+To connect to the epic server you need to provide a prefix, the private key and the certificate; alternatively the library also provides authentication with username/password. This information is stored in a json file *cred_file.json* and should look like this:
+```sh
+{
+    "handle_server_url": "https://epic3.storage.surfsara.nl:8001",
+    "private_key": "/<full path>/credentials/cred_b2handle/355_841_privkey.pem",
+    "certificate_only": "/<full path>/credentials/cred_b2handle/355_841_certificate_only.pem",
+    "prefix": "841",
+    "handleowner": "200:0.NA/841",
+    "reverse_username": "841",
+    "reverse_password": "****",
+    "HTTPS_verify": "True"
+}
+```
+On the user interface machines you can find such a file and all necessary certificates and keys in */<full path>/credentials/cred_b2handle/*. Please adopt the *<full path>* appropriately.
+
+- Parse credentials
+```py
+cred = PIDClientCredentials.load_from_JSON('<full_path>/cred_file.json')
+```
+- Retrieve some information about the server, this server also hosts the resolver which we will use later
+```py
+print('PID prefix ' + cred.get_prefix())
+print('Server ' + cred.get_server_URL())
+```
+
+- Create an instance of the client by oassing your credentials:
+```py
+ec = EUDATHandleClient.instantiate_with_credentials(cred)
+```
+
+## Registering a file
+### We will register a public file from figshare. 
+First store the file location.
+```py
+fileLocation = 'https://ndownloader.figshare.com/files/2292172'
+```
+
+### Building the PID:
+- Create a universally unique identifier (uuid)
+- Take function for this from
+```py
+import uuid
+uid = uuid.uuid1()
+print(uid)
+print(type(uid))
+```
+
+- Concatenate your PID prefix and the uuid to create the full PID
+```py
+pid = cred.get_prefix() + '/' + str(uid)
+print(pid)
+```
+
+We now have an opaque string which is unique to our resolver since
+the prefix is unique (handed out by administrators of the resolver).
+The suffix has been created with the uuid function. 
+
+- Link the PID and the data object. We would like the PID to point to the location we stored in *fileLocation*
+
+```py
+Handle = ec.register_handle(pid, fileLocation)
+```
+
+Let’s go to the resolver and see what is stored there
+`http://epic3.storage.surfsara.nl:8001`. 
+We can get some information on the data from the resolver.
+We can retrieve the data object itself via the web-browser.
+
+**Download the file via the resolver. Try to use *wget* when working remotely on our training machine.**
+
+**How is the data stored when downloading via the browser and how via *wget*?**
+
+**Have a look at the metadata stored in the PID entry.**
+
+**What happens if you try to reregister the file with the same PID?**
+```py
+newHandle = ec.createHandle(pid, fileLocation)
+```
+
+### Store some handy information with your file
+- We can store some more information in the PID entry with the function *modifyHandle*
+```py
+?ec.modify_handle_value
+```
+We can update and create several key-value pairs in one go. To this end we create a python dictionary and pass it to the function.
+```py
+args = dict([('TYPE', 'file')])
+ec.modify_handle_value(Handle, ttl=None, add_if_not_exist=True, **args)
+```
+
+- We want to store information on identity of the file, e.g. the md5 checksum. We first have 
+to generate the checksum. However, we can only create checksums for files which we 
+have access to with our python compiler. In the step above we can download the file and
+then continue to calculate the checksum. **NOTE** the filename might depend on the download method.
+
+```py
+import hashlib
+md5sum = hashlib.md5('/<PATH>/surveys.csv').hexdigest()
+args = dict([('TYPE', 'file'), ('MD5', md5sum)])
+ec.modify_handle_value(Handle, ttl=None, add_if_not_exist=True, **args)
+```
+
+- With the resolver we can access this information. Note, this data is publicly available to anyone.
+
+- We can also access the information via the client:
+    ```py
+    ec.retrieve_handle_record(Handle)
+    ```
+
+### Updating PID entries
+- Assume location of file has changed. This means we need to modify the URL field.
+
+```py
+ec.modify_handle_value(Handle, ttl=None, add_if_not_exist=True, **dict([('URL', '/<PATH>/surveys.csv')]))
+```
+
+**Try to fetch some metadata on the file from the resolver.**
+
+**Try to resolve directly to the file. What happens?**
+
+We updated the "URL" with a local path on a personal machine. That means you can no longer download the data
+directly, but you have access to the data stored in the PID.
+
+* Information stored with the PID is ALWAYS public
+* Data itself can lie on a protected server/computer and not be accessible for everyone
+
+## Linking two files
+We know that the file in the figshare repository and our local file are identical. We want to store this information
+in the PIDs.
+
+- Reregister the figshare file
+- First create a new PID
+```py
+uid = uuid.uuid1()
+print(uid)
+pid = cred.get_prefix() + '/' + str(uid)
+```
+
+- Link the new PID/handle to the public figshare data which is still stored in *fileLocation*
+
+```py
+newHandle = ec.register_handle(pid, fileLocation)
+```
+
+- Leave information that local file should be the same as the figshare file
+
+```py
+ec.modify_handle_value(Handle, ttl=None, add_if_not_exist=True, **dict([('REPLICA', newHandle)]))
+```
+
+### Reverse look-ups
+**TODO**
+The epic API extends the handle API with reverse look-ups. Assume you just know some of the metadata stored with a PID but not the full PID. How can you get to the URL field to retrieve the data?
+
+We can fetch the first data with a certain checksum:
+```py
+args = dict([('CHECKSUM', str(''.join(md5sum)))])
+Handle = ec.search_handle(**args)
+url = ec.get_value_from_handle(Handle, 'URL')
+print(url) 
+```
+
+### Using the epicclient Command Line Interface (CLI)
+For now we directly worked with the library. EUDAT provides an [epicclient](https://github.com/EUDAT-B2SAFE/B2SAFE-core/blob/master/cmd/epicclient2.py) which can be used as command line interface (CLI) based on the B2HANDLE. 
+You can list all options for the CLI on the commandline with:
+
+```sh 
+python epicclient2.py os <full path>/cred_file.json -h
+```
+
+The functions are adjusted to the functionality in the EUDAT B2SAFE service, but can serve as reference implementation for other use cases.


### PR DESCRIPTION
Most librarians know a lot about persistent identifiers like handles, DOIs and so forth. In the added files we try to explain a broader use of this technology.
The files contain the technical part and might need some padding and contextualisation with the rest of the library carpentry curriculum.

Adding a  very basic PID tutorial employing handles. The module was developed for the EUDAT (eudat.eu) training.