### PR TITLE
Add incubator flow to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Our **Alpha** lessons - those which are new or substantially revised and have th
 - [library-spreadsheets](https://github.com/jezcope/library-spreadsheets)
 - [data-intro-archives](https://github.com/data-lessons/data-intro-archives)
 
-If you plan to teach an **Alpha** or **Beta** status lesson at a Library Carpentry workshop, we recommend you contact the lessons maintainer (listed in the lesson README.md file) before doing so.
+If you plan to teach an **Alpha** or **Beta** status lesson at a Library Carpentry workshop, we recommend you contact the lesson's maintainer (listed in the lesson README.md file) before doing so.
 
 A lot of work was done on the repositories during the recent Mozilla Global sprint. For work outstanding, please see the [issues here](https://github.com/data-lessons/librarycarpentry/issues). Contributions welcome.
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ These four repositories have been re-developed within the GitHub `data-lessons` 
 
 Library Carpentry prides itself on reviewing and revising our lessons to ensure that they fit the needs and requriements of the communities we serve. As a result our lessons are at varying stages of maturity.
 
-Our core lessons - those which we are confident that anyone can teach with no problems - are:
+Our **Core** lessons - those which we are confident that anyone can teach with no problems - are:
 
 - [library-data-intro](https://github.com/data-lessons/library-data-intro)
 - [library-shell](https://github.com/data-lessons/library-shell)
 - [library-openrefine](https://github.com/data-lessons/library-openrefine)
 
-Our beta lessons - those which need to be taught more to iron out their content and flow - are:
+Our **Beta** lessons - those which need to be taught more to iron out their content and flow - are:
 
 - [library-git](https://github.com/data-lessons/library-git)
 - [library-python-intro](https://github.com/data-lessons/library-python-intro)
 - [library-python](https://github.com/data-lessons/library-python)
 - [library-sql](https://github.com/data-lessons/library-sql)
 
-Our alpha lessons - those which are new or substantially revised and have therefore yet to be tested in a teaching environment -  are:
+Our **Alpha** lessons - those which are new or substantially revised and have therefore yet to be tested in a teaching environment -  are:
 
 - [library-webscraping](https://github.com/data-lessons/library-webscraping)
 - [library-spreadsheets](https://github.com/jezcope/library-spreadsheets)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These four repositories have been re-developed within the GitHub `data-lessons` 
 
 ## Lessons
 
-Library Carpentry prides itself on reviewing and revising our lessons to ensure that they fit the needs and requriements of the communities we serve. As a result our lessons are at varying stages of maturity.
+Library Carpentry prides itself on reviewing and revising our lessons to ensure that they fit the needs and requirements of the communities we serve. As a result our lessons are at varying stages of maturity.
 
 Our **Core** lessons - those which we are confident that anyone can teach with no problems - are:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Our **Alpha** lessons - those which are new or substantially revised and have th
 - [library-spreadsheets](https://github.com/jezcope/library-spreadsheets)
 - [data-intro-archives](https://github.com/data-lessons/data-intro-archives)
 
+If you plan to teach an **Alpha** or **Beta** status lesson at a Library Carpentry workshop, we recommend you contact the lessons maintainer (listed in the lesson README.md file) before doing so.
+
 A lot of work was done on the repositories during the recent Mozilla Global sprint. For work outstanding, please see the [issues here](https://github.com/data-lessons/librarycarpentry/issues). Contributions welcome.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,27 +9,113 @@ Many of these materials are based on the **Library Carpentry** materials initial
 
 These four repositories have been re-developed within the GitHub `data-lessons` area, and new lessons have been added. All lessons are open to contributions, whether through pull requests or through issues raised on the repositories themselves.
 
+## Lessons
+
+Library Carpentry prides itself on reviewing and revising our lessons to ensure that they fit the needs and requriements of the communities we serve. As a result our lessons are at varying stages of maturity.
+
+Our core lessons - those which we are confident that anyone can teach with no problems - are:
+
 - [library-data-intro](https://github.com/data-lessons/library-data-intro)
 - [library-shell](https://github.com/data-lessons/library-shell)
-- [library-git](https://github.com/data-lessons/library-git)
 - [library-openrefine](https://github.com/data-lessons/library-openrefine)
-- [library-sql](https://github.com/data-lessons/library-sql)
+
+Our beta lessons - those which need to be taught more to iron out their content and flow - are:
+
+- [library-git](https://github.com/data-lessons/library-git)
 - [library-python-intro](https://github.com/data-lessons/library-python-intro)
 - [library-python](https://github.com/data-lessons/library-python)
+- [library-sql](https://github.com/data-lessons/library-sql)
+
+Our alpha lessons - those which are new or substantially revised and have therefore yet to be tested in a teaching environment -  are:
+
 - [library-webscraping](https://github.com/data-lessons/library-webscraping)
-
-## Other lessons
-
-There is a new Data Intro lesson specifically geared towards the needs of archivists:
-
-- [data-intro-archives](https://github.com/data-lessons/data-intro-archives)
-
-An incubator lesson exists within a separate repository for tidying spreadsheet data:
-
 - [library-spreadsheets](https://github.com/jezcope/library-spreadsheets)
+- [data-intro-archives](https://github.com/data-lessons/data-intro-archives)
 
 A lot of work was done on the repositories during the recent Mozilla Global sprint. For work outstanding, please see the [issues here](https://github.com/data-lessons/librarycarpentry/issues). Contributions welcome.
 
 ## License
 
-All the lessons are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/). **Exceptions: embeds to and from external sources, and direct quotations from speakers.**
+*Library Carpentry builds on the work of [Software
+Carpentry]({{site.swc_site}}) and [Data
+Carpentry]({{site.dc_site}}). It uses the same license as these
+projects. This can be found below.*
+
+### Instructional Material
+
+All Software Carpentry and Data Carpentry instructional material is
+made available under the [Creative Commons Attribution
+license][cc-by-human]. The following is a human-readable summary of
+(and not a substitute for) the [full legal text of the CC BY 4.0
+license][cc-by-legal].
+
+You are free:
+
+* to **Share**---copy and redistribute the material in any medium or format
+* to **Adapt**---remix, transform, and build upon the material
+
+for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the
+license terms.
+
+Under the following terms:
+
+* **Attribution**---You must give appropriate credit (mentioning that
+  your work is derived from work that is Copyright © Software
+  Carpentry and, where practical, linking to
+  http://software-carpentry.org/), provide a [link to the
+  license][cc-by-human], and indicate if changes were made. You may do
+  so in any reasonable manner, but not in any way that suggests the
+  licensor endorses you or your use.
+
+**No additional restrictions**---You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.  With the understanding that:
+
+Notices:
+
+* You do not have to comply with the license for elements of the
+  material in the public domain or where your use is permitted by an
+  applicable exception or limitation.
+* No warranties are given. The license may not give you all of the
+  permissions necessary for your intended use. For example, other
+  rights such as publicity, privacy, or moral rights may limit how you
+  use the material.
+
+### Software
+
+Except where otherwise noted, the example programs and other software
+provided by Software Carpentry and Data Carpentry are made available under the
+[OSI][osi]-approved
+[MIT license][mit-license].
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### Trademark
+
+"Software Carpentry" and "Data Carpentry" and their respective logos
+are registered trademarks of [NumFOCUS][numfocus].
+
+[cc-by-human]: https://creativecommons.org/licenses/by/4.0/
+[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
+[mit-license]: http://opensource.org/licenses/mit-license.html
+[numfocus]: http://numfocus.org/
+[osi]: http://opensource.org


### PR DESCRIPTION
Okay. Further to @weaverbel unsprinting the repo, I've tried to represent in the readme where we are with different lessons using the schema @jezcope developed for lesson status http://pad.software-carpentry.org/library-carpentry-incubator

I'm not sure where some of these lessons are post-sprint, so I'd be grateful of input from maintainers: especially @richyvk and @c-martinez on python and python-intro (and, indeed, @elliewix as I know you did LOADS of work on these) and @mkuzak on SQL.

I should say that my ascription of status is no criticism of the lesson development, I'd just rather we were honest with those coming to the lessons. In time, we'll build the status into the webpages for each lesson and their READMEs, et cetera.